### PR TITLE
Add support for Debian Wheezy and HamServerPi

### DIFF
--- a/hamprobe-probe/hamprobe.init
+++ b/hamprobe-probe/hamprobe.init
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          hamprobe
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Hamprobe
+# Description:       Hamprobe
+### END INIT INFO
+
+# This init script is based on the skeleton available at http://blog.scphillips.com/posts/2013/07/getting-a-python-script-to-run-in-the-background-as-a-service-on-boot/
+
+DIR=/usr/local/bin
+DAEMON=$DIR/hamprobe_master.py
+DAEMON_NAME=hamprobe_master
+DAEMON_OPTS="--config /etc/hamprobe.conf run"
+DAEMON_USER=root
+
+# The process ID of the script when it runs is stored here:
+PIDFILE=/var/run/$DAEMON_NAME.pid
+
+. /lib/lsb/init-functions
+
+do_start () {
+    log_daemon_msg "Starting system $DAEMON_NAME daemon"
+    start-stop-daemon --start --background --pidfile $PIDFILE --make-pidfile --user $DAEMON_USER --chuid $DAEMON_USER --chdir $DIR --exec $DAEMON -- $DAEMON_OPTS
+    log_end_msg $?
+}
+do_stop () {
+    log_daemon_msg "Stopping system $DAEMON_NAME daemon"
+    start-stop-daemon --stop --pidfile $PIDFILE --retry 10
+    log_end_msg $?
+}
+
+case "$1" in
+
+    start|stop)
+        do_${1}
+        ;;
+
+    restart|reload|force-reload)
+        do_stop
+        do_start
+        ;;
+
+    status)
+        status_of_proc "$DAEMON_NAME" "$DAEMON" && exit 0 || exit $?
+        ;;
+
+    *)
+        echo "Usage: /etc/init.d/$DAEMON_NAME {start|stop|restart|status}"
+        exit 1
+        ;;
+
+esac
+exit 0
+

--- a/hamprobe-probe/hamprobe_install.sh
+++ b/hamprobe-probe/hamprobe_install.sh
@@ -11,8 +11,16 @@ chmod 744 "/usr/local/bin/hamprobe_master.py"
 wget -O "/etc/hamprobe.conf" "http://api.hamprobe.net/assets/hamprobe.conf"
 chmod 600 "/etc/hamprobe.conf"
 
-wget -O "/etc/systemd/system/hamprobe.service" "http://api.hamprobe.net/assets/hamprobe.service"
+if pidof systemd > /dev/null; then
+	# Systemd
+	wget -O "/etc/systemd/system/hamprobe.service" "http://api.hamprobe.net/assets/hamprobe.service"
+	systemctl daemon-reload
+	systemctl enable hamprobe
+	systemctl start hamprobe
 
-systemctl daemon-reload
-systemctl enable hamprobe
-systemctl start hamprobe
+else
+	# SysVInit
+	wget -O "/etc/init.d/hamprobe" "http://api.hamprobe.net/assets/hamprobe.init"
+	update-rc.d hamprobe defaults
+	/etc/init.d/hamprobe start
+fi


### PR DESCRIPTION
This commit adds support for Debian Wheezy and its derivates. A lot of servers
on the HAMNET use HamServerPi, which sadly still depends on Debian Wheezy.
Wheezy comes with Python 3.2 and SysVInit preinstalled. This commit is a first
approach to adding support to those legacy program versions.

Good luck with your bachelors thesis!

Signed-off-by: Anton Würfel DL8AW <info@dl8aw.de>